### PR TITLE
Improve navigation drawer management and ease of use

### DIFF
--- a/app/src/main/java/ch/dc/shipment_tracking_app/AboutUsActivity.java
+++ b/app/src/main/java/ch/dc/shipment_tracking_app/AboutUsActivity.java
@@ -1,68 +1,14 @@
 package ch.dc.shipment_tracking_app;
 
-import androidx.annotation.NonNull;
-import androidx.appcompat.app.ActionBarDrawerToggle;
-import androidx.appcompat.app.AppCompatActivity;
-import androidx.appcompat.widget.Toolbar;
-import androidx.core.view.GravityCompat;
-import androidx.drawerlayout.widget.DrawerLayout;
-
 import android.os.Bundle;
-import android.view.MenuItem;
 
-import com.google.android.material.navigation.NavigationView;
-
-public class AboutUsActivity extends BaseActivity implements NavigationView.OnNavigationItemSelectedListener{
-
-    private DrawerLayout drawer;
+public class AboutUsActivity extends BaseActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_about_us);
 
-        //Make our toolbar as the action bar.
-        Toolbar toolbar = findViewById(R.id.toolbar);
-        setSupportActionBar(toolbar);
-
-        drawer = findViewById(R.id.drawer_layout);
-
-        NavigationView navigationView = findViewById(R.id.nav_view);
-        navigationView.setNavigationItemSelectedListener(this);
-
-        //Add the menu button on the app bar and moves it dynamically when the drawer opens or closes.
-        ActionBarDrawerToggle toggle = new ActionBarDrawerToggle(this, drawer, toolbar,
-                R.string.navigation_drawer_open, R.string.navigation_drawer_close);
-        drawer.addDrawerListener(toggle);
-        toggle.syncState();
-
-    }
-
-    @Override
-    public boolean onNavigationItemSelected(@NonNull MenuItem item) {
-        switch (item.getItemId()) {
-            case R.id.nav_home:
-                MainActivity.redirectActivity(this, MainActivity.class);
-                break;
-            case R.id.nav_settings:
-                MainActivity.redirectActivity(this, SettingsActivity.class);
-                break;
-            case R.id.nav_about_us:
-                drawer.closeDrawer(GravityCompat.START);
-                break;
-        }
-
-        drawer.closeDrawer(GravityCompat.START);
-        return true;
-    }
-
-    //When the drawer is open, pressing on the back button will close the drawer instead of going back.
-    @Override
-    public void onBackPressed() {
-        if (drawer.isDrawerOpen(GravityCompat.START)) {
-            drawer.closeDrawer(GravityCompat.START);
-        } else {
-            super.onBackPressed();
-        }
+        attachNavigationMenu();
     }
 }

--- a/app/src/main/java/ch/dc/shipment_tracking_app/BaseActivity.java
+++ b/app/src/main/java/ch/dc/shipment_tracking_app/BaseActivity.java
@@ -1,22 +1,50 @@
 package ch.dc.shipment_tracking_app;
 
+import android.app.Activity;
 import android.content.Context;
+import android.content.Intent;
 import android.os.Bundle;
+import android.view.MenuItem;
 
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.ActionBarDrawerToggle;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
+import androidx.core.view.GravityCompat;
+import androidx.drawerlayout.widget.DrawerLayout;
+
+import com.google.android.material.navigation.NavigationView;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import ch.dc.shipment_tracking_app.internationalization.LocaleHelper;
 
-public abstract class BaseActivity extends AppCompatActivity {
+public abstract class BaseActivity extends AppCompatActivity implements NavigationView.OnNavigationItemSelectedListener {
+
+    private static Map<Integer, Class<? extends BaseActivity>> navigationDrawerRoutes;
+
+    private DrawerLayout drawer;
 
     private String initialLocale;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        initialLocale = LocaleHelper.getLocaleFromSharedPreference(getBaseContext());
-    }
 
+        initialLocale = LocaleHelper.getLocaleFromSharedPreference(getBaseContext());
+
+        // Set a default activity title. Any activity can define its proper title by calling this method.
+        setTitle(getString(R.string.app_name));
+
+        // Define the navigation drawer routes.
+        if (navigationDrawerRoutes == null) {
+            navigationDrawerRoutes = new HashMap<>();
+            navigationDrawerRoutes.put(R.id.nav_home, MainActivity.class);
+            navigationDrawerRoutes.put(R.id.nav_settings, SettingsActivity.class);
+            navigationDrawerRoutes.put(R.id.nav_about_us, AboutUsActivity.class);
+        }
+    }
 
     @Override
     protected void attachBaseContext(Context baseContext) {
@@ -33,5 +61,66 @@ public abstract class BaseActivity extends AppCompatActivity {
         if (initialLocale != null && !initialLocale.equals(localeFromSharedPreference)) {
             recreate();
         }
+    }
+
+    @Override
+    public boolean onNavigationItemSelected(@NonNull MenuItem item) {
+        Class<? extends BaseActivity> callingClass = this.getClass();
+        Class<? extends BaseActivity> destinationClass = navigationDrawerRoutes.get(item.getItemId());
+
+        if (destinationClass != null) {
+            if (callingClass != destinationClass) {
+                redirectActivity(this, destinationClass);
+            }
+        }
+
+        drawer.closeDrawer(GravityCompat.START);
+        return true;
+    }
+
+    /**
+     * When the drawer is open, pressing on the back button will close the drawer
+     * instead of going back.
+     */
+    @Override
+    public void onBackPressed() {
+        if (drawer.isDrawerOpen(GravityCompat.START)) {
+            drawer.closeDrawer(GravityCompat.START);
+        } else {
+            super.onBackPressed();
+        }
+    }
+
+    /**
+     * Enable the navigation drawer on an activity.
+     * Call this method in the {@code onCreate()} method of your activity if you want to use
+     * the navigation drawer.
+     *
+     */
+    public void attachNavigationMenu() {
+        //Make our toolbar as the action bar.
+        Toolbar toolbar = findViewById(R.id.toolbar);
+        setSupportActionBar(toolbar);
+
+        drawer = findViewById(R.id.drawer_layout);
+
+        NavigationView navigationView = findViewById(R.id.nav_view);
+        navigationView.setNavigationItemSelectedListener(this);
+
+        //Add the menu button on the app bar and moves it dynamically when the drawer opens or closes.
+        ActionBarDrawerToggle toggle = new ActionBarDrawerToggle(this, drawer, toolbar,
+                R.string.navigation_drawer_open, R.string.navigation_drawer_close);
+        drawer.addDrawerListener(toggle);
+        toggle.syncState();
+    }
+
+    /**
+     * Convient method to redirect to an activity
+     * @param context The context calling the method.
+     * @param aClass The class to go to.
+     */
+    public final void redirectActivity(Activity context, Class<?> aClass) {
+        Intent intent = new Intent(context, aClass);
+        context.startActivity(intent);
     }
 }

--- a/app/src/main/java/ch/dc/shipment_tracking_app/ClientMainActivity.java
+++ b/app/src/main/java/ch/dc/shipment_tracking_app/ClientMainActivity.java
@@ -1,7 +1,5 @@
 package ch.dc.shipment_tracking_app;
 
-import androidx.appcompat.app.AppCompatActivity;
-
 import android.os.Bundle;
 import android.view.View;
 
@@ -14,6 +12,6 @@ public class ClientMainActivity extends BaseActivity {
     }
 
     public void sendPackage(View view) {
-        MainActivity.redirectActivity(this, ClientSendPackageActivity.class);
+        redirectActivity(this, ClientSendPackageActivity.class);
     }
 }

--- a/app/src/main/java/ch/dc/shipment_tracking_app/ClientSendPackageActivity.java
+++ b/app/src/main/java/ch/dc/shipment_tracking_app/ClientSendPackageActivity.java
@@ -16,6 +16,7 @@ import android.widget.Toast;
 
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
+import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.app.ActivityCompat;
 

--- a/app/src/main/java/ch/dc/shipment_tracking_app/MainActivity.java
+++ b/app/src/main/java/ch/dc/shipment_tracking_app/MainActivity.java
@@ -1,81 +1,19 @@
 package ch.dc.shipment_tracking_app;
 
-import android.app.Activity;
-import android.content.Intent;
 import android.os.Bundle;
-import android.view.MenuItem;
 import android.view.View;
 
-import androidx.annotation.NonNull;
-import androidx.appcompat.app.ActionBarDrawerToggle;
-import androidx.appcompat.app.AppCompatActivity;
-import androidx.appcompat.widget.Toolbar;
-import androidx.core.view.GravityCompat;
-import androidx.drawerlayout.widget.DrawerLayout;
-
-import com.google.android.material.navigation.NavigationView;
-
-public class MainActivity extends BaseActivity implements NavigationView.OnNavigationItemSelectedListener {
-
-    private DrawerLayout drawer;
-
+public class MainActivity extends BaseActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
+        super.onCreate(savedInstanceState);
 
-        //Make our toolbar as the action bar.
-        Toolbar toolbar = findViewById(R.id.toolbar);
-        setSupportActionBar(toolbar);
-
-        drawer = findViewById(R.id.drawer_layout);
-
-        NavigationView navigationView = findViewById(R.id.nav_view);
-        navigationView.setNavigationItemSelectedListener(this);
-
-        //Add the menu button on the app bar and moves it dynamically when the drawer opens or closes.
-        ActionBarDrawerToggle toggle = new ActionBarDrawerToggle(this, drawer, toolbar,
-                R.string.navigation_drawer_open, R.string.navigation_drawer_close);
-        drawer.addDrawerListener(toggle);
-        toggle.syncState();
-
+        attachNavigationMenu();
     }
 
     public void goClientSide (View view) {
         redirectActivity(this, ClientMainActivity.class);
-    }
-
-    @Override
-    public boolean onNavigationItemSelected(@NonNull MenuItem item) {
-        switch (item.getItemId()) {
-            case R.id.nav_home:
-                drawer.closeDrawer(GravityCompat.START);
-                break;
-            case R.id.nav_settings:
-                redirectActivity(this, SettingsActivity.class);
-                break;
-            case R.id.nav_about_us:
-                redirectActivity(this, AboutUsActivity.class);
-                break;
-        }
-
-        drawer.closeDrawer(GravityCompat.START);
-        return true;
-    }
-
-    //When the drawer is open, pressing on the back button will close the drawer instead of going back.
-    @Override
-    public void onBackPressed() {
-        if (drawer.isDrawerOpen(GravityCompat.START)) {
-            drawer.closeDrawer(GravityCompat.START);
-        } else {
-            super.onBackPressed();
-        }
-    }
-
-    public static void redirectActivity(Activity activity, Class aClass) {
-        Intent intent = new Intent(activity, aClass);
-        activity.startActivity(intent);
     }
 }

--- a/app/src/main/java/ch/dc/shipment_tracking_app/SettingsActivity.java
+++ b/app/src/main/java/ch/dc/shipment_tracking_app/SettingsActivity.java
@@ -1,72 +1,19 @@
 package ch.dc.shipment_tracking_app;
 
 import android.os.Bundle;
-import android.view.MenuItem;
 
-import androidx.annotation.NonNull;
-import androidx.appcompat.app.ActionBarDrawerToggle;
-import androidx.appcompat.app.AppCompatActivity;
-import androidx.appcompat.widget.Toolbar;
-import androidx.core.view.GravityCompat;
-import androidx.drawerlayout.widget.DrawerLayout;
-
-import com.google.android.material.navigation.NavigationView;
-
-public class SettingsActivity extends BaseActivity implements NavigationView.OnNavigationItemSelectedListener {
-
-    private DrawerLayout drawer;
+public class SettingsActivity extends BaseActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_settings);
 
+        attachNavigationMenu();
+
         getSupportFragmentManager()
                 .beginTransaction()
                 .replace(R.id.preference_fragment_container, new PreferenceFragment())
                 .commit();
-
-        //Make our toolbar as the action bar.
-        Toolbar toolbar = findViewById(R.id.toolbar);
-        setSupportActionBar(toolbar);
-
-        drawer = findViewById(R.id.drawer_layout);
-
-        NavigationView navigationView = findViewById(R.id.nav_view);
-        navigationView.setNavigationItemSelectedListener(this);
-
-        //Add the menu button on the app bar and moves it dynamically when the drawer opens or closes.
-        ActionBarDrawerToggle toggle = new ActionBarDrawerToggle(this, drawer, toolbar,
-                R.string.navigation_drawer_open, R.string.navigation_drawer_close);
-        drawer.addDrawerListener(toggle);
-        toggle.syncState();
-    }
-
-    @Override
-    public boolean onNavigationItemSelected(@NonNull MenuItem item) {
-        switch (item.getItemId()) {
-            case R.id.nav_home:
-                MainActivity.redirectActivity(this, MainActivity.class);
-                break;
-            case R.id.nav_settings:
-                drawer.closeDrawer(GravityCompat.START);
-                break;
-            case R.id.nav_about_us:
-                MainActivity.redirectActivity(this, AboutUsActivity.class);
-                break;
-        }
-
-        drawer.closeDrawer(GravityCompat.START);
-        return true;
-    }
-
-    //When the drawer is open, pressing on the back button will close the drawer instead of going back.
-    @Override
-    public void onBackPressed() {
-        if (drawer.isDrawerOpen(GravityCompat.START)) {
-            drawer.closeDrawer(GravityCompat.START);
-        } else {
-            super.onBackPressed();
-        }
     }
 }

--- a/app/src/main/res/layout/navigation_view.xml
+++ b/app/src/main/res/layout/navigation_view.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <com.google.android.material.navigation.NavigationView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/nav_view"
     android:layout_width="wrap_content"
     android:layout_height="match_parent"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_gravity="start"
-    android:id="@+id/nav_view"
     app:headerLayout="@layout/nav_header"
     app:menu="@menu/drawer_menu">
 


### PR DESCRIPTION
Move the navigation drawer management from the `MainActivity` class to the `BaseActivity` class to avoid code repetition.

Making this change allows :
- to add / modify / delete the navigation drawer routes in only one class (`BaseActivity`)
- every Activity that extends `BaseActivity` to use the navigation drawer without adding any new code in the Activity itself